### PR TITLE
chore: pin grunt-mocha to 1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "grunt-contrib-concat": "^1.0.1",
     "grunt-contrib-copy": "^1.0.0",
     "grunt-contrib-uglify": "^2.0.0",
-    "grunt-mocha": "^1.0.2",
+    "grunt-mocha": "1.0.2",
     "grunt-mocha-test": "^0.13.2",
     "load-grunt-tasks": "^3.2.0",
     "time-grunt": "^1.2.1"


### PR DESCRIPTION
Closes #2, closes #3, closes #4, and closes #5.